### PR TITLE
Add workflow for trusted publishing

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,70 @@
+# This workflow will upload a Python Package to PyPI when a release is created
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-package-registries
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Upload Python Package
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  release-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Build release distributions
+        run: |
+          # NOTE: put your own distribution build steps here.
+          python -m pip install build
+          python -m build
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-dists
+          path: dist/
+
+  pypi-publish:
+    runs-on: ubuntu-latest
+    needs:
+      - release-build
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
+
+    # Dedicated environments with protections for publishing are strongly recommended.
+    # For more information, see: https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment#deployment-protection-rules
+    environment:
+      name: pypi
+      # OPTIONAL: uncomment and update to include your PyPI project URL in the deployment status:
+      # url: https://pypi.org/p/YOURPROJECT
+      #
+      # ALTERNATIVE: if your GitHub Release name is the PyPI project version string
+      # ALTERNATIVE: exactly, uncomment the following line instead:
+      # url: https://pypi.org/project/YOURPROJECT/${{ github.event.release.name }}
+
+    steps:
+      - name: Retrieve release distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: release-dists
+          path: dist/
+
+      - name: Publish release distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -9,6 +9,7 @@
 name: Upload Python Package
 
 on:
+  pull_request:
   release:
     types: [published]
 

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -80,3 +80,4 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist/
+          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -26,6 +26,10 @@ jobs:
         with:
           python-version: "3.x"
 
+      - name: Build C bindings
+        run: |
+          make build-bindings
+
       - name: Build release distributions
         run: |
           # NOTE: put your own distribution build steps here.

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -9,7 +9,6 @@
 name: Upload Python Package
 
 on:
-  pull_request:
   release:
     types: [published]
 
@@ -37,7 +36,6 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: "1.24.2"
-      - run: go version
 
       - name: Build C bindings
         run: |

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -9,9 +9,16 @@
 name: Upload Python Package
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
-  release:
-    types: [published]
+  schedule:
+    - cron: "0 0 * * *"
+# on:
+#   pull_request:
+#   release:
+#     types: [published]
 
 permissions:
   contents: read

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -22,6 +22,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -9,16 +9,9 @@
 name: Upload Python Package
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
-  schedule:
-    - cron: "0 0 * * *"
-# on:
-#   pull_request:
-#   release:
-#     types: [published]
+  release:
+    types: [published]
 
 permissions:
   contents: read

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -25,6 +25,10 @@ jobs:
         with:
           submodules: recursive
           fetch-tags: true
+          # fetch-depth:0 is set because we need the tags in order to derive the version
+          # due to how pyscaffold set things up, but there is apparently a bug with fetch-tags.
+          # https://github.com/actions/checkout/issues/1471
+          fetch-depth: 0
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -24,6 +24,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+          fetch-tags: true
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -27,6 +27,11 @@ jobs:
         with:
           python-version: "3.x"
 
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.24.2"
+      - run: go version
+
       - name: Build C bindings
         run: |
           make build-bindings

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -40,7 +40,6 @@ jobs:
 
       - name: Build release distributions
         run: |
-          # NOTE: put your own distribution build steps here.
           python -m pip install build
           python -m build
 
@@ -81,3 +80,4 @@ jobs:
         with:
           packages-dir: dist/
           repository-url: https://test.pypi.org/legacy/
+          verbose: true


### PR DESCRIPTION
This adds a workflow that will build the bindings for the package along with the package itself, then publish to PyPi. I've confirmed that the build works, but publishing isn't working yet due to a problem with the versioning. It's possible that the problem is that I'm creating a tag for something that isn't the default branch and that's causing the version to be a "development" version. I will merge this and tag a new release on `main` and go from there.