### PR TITLE
Build without platform tag

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,10 +11,10 @@ from setuptools import setup
 from setuptools.dist import Distribution
 
 
-class BinaryDistribution(Distribution):
-    """Distribution which always forces a binary package with platform name"""
-    def has_ext_modules(foo):
-        return True
+# class BinaryDistribution(Distribution):
+#     """Distribution which always forces a binary package with platform name"""
+#     def has_ext_modules(foo):
+#         return True
 
 
 if __name__ == "__main__":
@@ -25,7 +25,7 @@ if __name__ == "__main__":
             package_data={
                 '':['libuplink.so']
             },
-            distclass=BinaryDistribution
+            # distclass=BinaryDistribution
         )
     except:  # noqa
         print(

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,9 @@ from setuptools import setup
 from setuptools.dist import Distribution
 
 
+# TODO: Consider re-enabling the distclass and/or looking into cibuildwheel
+# in order to make sure that package works on the right platform
+#
 # class BinaryDistribution(Distribution):
 #     """Distribution which always forces a binary package with platform name"""
 #     def has_ext_modules(foo):


### PR DESCRIPTION
This is essentially a revert of 60ecd417b1fb938ba827870def56c7c9db2c5b94. I put this in place because Storj offers multiple downloads for `uplink` - for arm64 and amd64. Because I'm building the binary on a specific platform I assumed that a wheel with `any` would break on some platforms. With the current CI setup this is the error that was returned from pypi:


```
          'storj_uplink-0.1.4-cp313-cp313-linux_x86_64.whl' has an unsupported   
         platform tag 'linux_x86_64'.</title>                                   
          </head>                                                               
          <body>                                                                
           <h1>400 Binary wheel                                                 
         'storj_uplink-0.1.4-cp313-cp313-linux_x86_64.whl' has an unsupported   
         platform tag 'linux_x86_64'.</h1>
 ````
 
 This change should remove the `linux_x86_64` platform tag which should allow pypi to accept it, but I'm not convinced that it will work for all devices. Once I do more testing I may end up using [cibuildwheel][1].
 
 [1]: https://github.com/pypa/cibuildwheel