### PR TITLE
Try building for musl on arm64

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -31,6 +31,7 @@ jobs:
             go
             python3
             py3-pip
+            py3-build
             make
 
       - id: go-cache-paths
@@ -81,7 +82,7 @@ jobs:
 
       - name: Build release distributions
         run: |
-          python -m pip install build
+          # python -m pip install build
           python -m build
         shell: alpine.sh --root {0}
 

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -39,6 +39,7 @@ jobs:
         run: |
           echo "go-build=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
           echo "go-mod=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
+        shell: alpine.sh --root {0}
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -9,6 +9,7 @@
 name: Upload Python Package
 
 on:
+  pull_request:
   release:
     types: [published]
 
@@ -60,34 +61,34 @@ jobs:
           name: release-dists
           path: dist/
 
-  pypi-publish:
-    runs-on: ubuntu-latest
-    needs:
-      - release-build
-    permissions:
-      # IMPORTANT: this permission is mandatory for trusted publishing
-      id-token: write
-
-    # Dedicated environments with protections for publishing are strongly recommended.
-    # For more information, see: https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment#deployment-protection-rules
-    environment:
-      name: pypi
-      # OPTIONAL: uncomment and update to include your PyPI project URL in the deployment status:
-      # url: https://pypi.org/p/YOURPROJECT
-      #
-      # ALTERNATIVE: if your GitHub Release name is the PyPI project version string
-      # ALTERNATIVE: exactly, uncomment the following line instead:
-      # url: https://pypi.org/project/YOURPROJECT/${{ github.event.release.name }}
-
-    steps:
-      - name: Retrieve release distributions
-        uses: actions/download-artifact@v4
-        with:
-          name: release-dists
-          path: dist/
-
-      - name: Publish release distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          packages-dir: dist/
-          verbose: true
+  # pypi-publish:
+  #   runs-on: ubuntu-latest
+  #   needs:
+  #     - release-build
+  #   permissions:
+  #     # IMPORTANT: this permission is mandatory for trusted publishing
+  #     id-token: write
+  #
+  #   # Dedicated environments with protections for publishing are strongly recommended.
+  #   # For more information, see: https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment#deployment-protection-rules
+  #   environment:
+  #     name: pypi
+  #     # OPTIONAL: uncomment and update to include your PyPI project URL in the deployment status:
+  #     # url: https://pypi.org/p/YOURPROJECT
+  #     #
+  #     # ALTERNATIVE: if your GitHub Release name is the PyPI project version string
+  #     # ALTERNATIVE: exactly, uncomment the following line instead:
+  #     # url: https://pypi.org/project/YOURPROJECT/${{ github.event.release.name }}
+  #
+  #   steps:
+  #     - name: Retrieve release distributions
+  #       uses: actions/download-artifact@v4
+  #       with:
+  #         name: release-dists
+  #         path: dist/
+  #
+  #     - name: Publish release distributions to PyPI
+  #       uses: pypa/gh-action-pypi-publish@release/v1
+  #       with:
+  #         packages-dir: dist/
+  #         verbose: true

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -20,6 +20,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Setup Alpine Linux v3.15 for aarch64
+        uses: jirutka/setup-alpine@v1
+        with:
+          arch: aarch64
+          branch: v3.15
+
       - uses: actions/checkout@v4
         with:
           submodules: recursive
@@ -40,11 +46,13 @@ jobs:
       - name: Build C bindings
         run: |
           make build-bindings
+        shell: alpine.sh {0}
 
       - name: Build release distributions
         run: |
           python -m pip install build
           python -m build
+        shell: alpine.sh {0}
 
       - name: Upload distributions
         uses: actions/upload-artifact@v4

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -43,6 +43,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: "1.24.2"
+        shell: alpine.sh --root {0}
 
       - name: Install make for Alpine
         run: |

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -27,6 +27,7 @@ jobs:
           arch: aarch64
           branch: v3.21
           packages: >
+            build-base
             go
             make
 

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -64,19 +64,6 @@ jobs:
           path: ${{ steps.go-cache-paths.outputs.go-mod }}
           key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
 
-      # - uses: actions/setup-python@v5
-      #   with:
-      #     python-version: "3.x"
-
-      # - uses: actions/setup-go@v5
-      #   with:
-      #     go-version: "1.24.2"
-
-      # - name: Install make for Alpine
-      #   run: |
-      #     apk add --no-cache make
-      #   shell: alpine.sh --root {0}
-
       - name: Build C bindings
         run: |
           make build-bindings
@@ -86,7 +73,6 @@ jobs:
 
       - name: Build release distributions
         run: |
-          # python -m pip install build
           python -m build
         shell: alpine.sh --root {0}
 

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -29,6 +29,7 @@ jobs:
           packages: >
             build-base
             go
+            python
             make
 
       - uses: actions/checkout@v4
@@ -40,9 +41,9 @@ jobs:
           # https://github.com/actions/checkout/issues/1471
           fetch-depth: 0
 
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.x"
+      # - uses: actions/setup-python@v5
+      #   with:
+      #     python-version: "3.x"
 
       # - uses: actions/setup-go@v5
       #   with:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -47,18 +47,18 @@ jobs:
       - name: Install make for Alpine
         run: |
           apk add --no-cache make
-        shell: alpine.sh {0}
+        shell: alpine.sh --root {0}
 
       - name: Build C bindings
         run: |
           make build-bindings
-        shell: alpine.sh {0}
+        shell: alpine.sh --root {0}
 
       - name: Build release distributions
         run: |
           python -m pip install build
           python -m build
-        shell: alpine.sh {0}
+        shell: alpine.sh --root {0}
 
       - name: Upload distributions
         uses: actions/upload-artifact@v4

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -49,14 +49,14 @@ jobs:
 
         # Cache go build cache, used to speedup go test
       - name: Go Build Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ steps.go-cache-paths.outputs.go-build }}
           key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
 
       # Cache go mod cache, used to speedup builds
       - name: Go Mod Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ steps.go-cache-paths.outputs.go-mod }}
           key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -29,7 +29,7 @@ jobs:
           packages: >
             build-base
             go
-            python
+            python3
             make
 
       - uses: actions/checkout@v4

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -30,6 +30,7 @@ jobs:
             build-base
             go
             python3
+            py3-pip
             make
 
       - uses: actions/checkout@v4

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -80,6 +80,8 @@ jobs:
         run: |
           make build-bindings
         shell: alpine.sh --root {0}
+        env:
+          GOFLAGS: -buildvcs=false
 
       - name: Build release distributions
         run: |

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -21,11 +21,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Setup Alpine Linux v3.15 for aarch64
+      - name: Setup Alpine Linux v3.21 for aarch64
         uses: jirutka/setup-alpine@v1
         with:
           arch: aarch64
-          branch: v3.15
+          branch: v3.21
           packages: >
             go
             make

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -34,12 +34,6 @@ jobs:
             py3-build
             make
 
-      - id: go-cache-paths
-        run: |
-          echo "go-build=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
-          echo "go-mod=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
-        shell: alpine.sh --root {0}
-
       - uses: actions/checkout@v4
         with:
           submodules: recursive
@@ -48,20 +42,6 @@ jobs:
           # due to how pyscaffold set things up, but there is apparently a bug with fetch-tags.
           # https://github.com/actions/checkout/issues/1471
           fetch-depth: 0
-
-        # Cache go build cache, used to speedup go test
-      - name: Go Build Cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.go-cache-paths.outputs.go-build }}
-          key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
-
-      # Cache go mod cache, used to speedup builds
-      - name: Go Mod Cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.go-cache-paths.outputs.go-mod }}
-          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
 
       - name: Build C bindings
         run: |

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -81,7 +81,7 @@ jobs:
           make build-bindings
         shell: alpine.sh --root {0}
         env:
-          GOFLAGS: -buildvcs=false
+          GOFLAGS: "-buildvcs=false"
 
       - name: Build release distributions
         run: |

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -44,6 +44,11 @@ jobs:
         with:
           go-version: "1.24.2"
 
+      - name: Install make for Alpine
+        run: |
+          apk add --no-cache make
+        shell: alpine.sh {0}
+
       - name: Build C bindings
         run: |
           make build-bindings

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -37,8 +37,8 @@ jobs:
 
       - id: go-cache-paths
         run: |
-          echo "::set-output name=go-build::$(go env GOCACHE)"
-          echo "::set-output name=go-mod::$(go env GOMODCACHE)"
+          echo "go-build=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
+          echo "go-mod=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -28,6 +28,7 @@ jobs:
           branch: v3.21
           packages: >
             build-base
+            git
             go
             python3
             py3-pip

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -9,7 +9,6 @@
 name: Upload Python Package
 
 on:
-  pull_request:
   release:
     types: [published]
 
@@ -82,34 +81,34 @@ jobs:
           name: release-dists
           path: dist/
 
-  # pypi-publish:
-  #   runs-on: ubuntu-latest
-  #   needs:
-  #     - release-build
-  #   permissions:
-  #     # IMPORTANT: this permission is mandatory for trusted publishing
-  #     id-token: write
-  #
-  #   # Dedicated environments with protections for publishing are strongly recommended.
-  #   # For more information, see: https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment#deployment-protection-rules
-  #   environment:
-  #     name: pypi
-  #     # OPTIONAL: uncomment and update to include your PyPI project URL in the deployment status:
-  #     # url: https://pypi.org/p/YOURPROJECT
-  #     #
-  #     # ALTERNATIVE: if your GitHub Release name is the PyPI project version string
-  #     # ALTERNATIVE: exactly, uncomment the following line instead:
-  #     # url: https://pypi.org/project/YOURPROJECT/${{ github.event.release.name }}
-  #
-  #   steps:
-  #     - name: Retrieve release distributions
-  #       uses: actions/download-artifact@v4
-  #       with:
-  #         name: release-dists
-  #         path: dist/
-  #
-  #     - name: Publish release distributions to PyPI
-  #       uses: pypa/gh-action-pypi-publish@release/v1
-  #       with:
-  #         packages-dir: dist/
-  #         verbose: true
+  pypi-publish:
+    runs-on: ubuntu-latest
+    needs:
+      - release-build
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
+
+    # Dedicated environments with protections for publishing are strongly recommended.
+    # For more information, see: https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment#deployment-protection-rules
+    environment:
+      name: pypi
+      # OPTIONAL: uncomment and update to include your PyPI project URL in the deployment status:
+      # url: https://pypi.org/p/YOURPROJECT
+      #
+      # ALTERNATIVE: if your GitHub Release name is the PyPI project version string
+      # ALTERNATIVE: exactly, uncomment the following line instead:
+      # url: https://pypi.org/project/YOURPROJECT/${{ github.event.release.name }}
+
+    steps:
+      - name: Retrieve release distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: release-dists
+          path: dist/
+
+      - name: Publish release distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
+          verbose: true

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -26,6 +26,9 @@ jobs:
         with:
           arch: aarch64
           branch: v3.15
+          packages: >
+            go
+            make
 
       - uses: actions/checkout@v4
         with:
@@ -40,15 +43,14 @@ jobs:
         with:
           python-version: "3.x"
 
-      - uses: actions/setup-go@v5
-        with:
-          go-version: "1.24.2"
-        shell: alpine.sh --root {0}
+      # - uses: actions/setup-go@v5
+      #   with:
+      #     go-version: "1.24.2"
 
-      - name: Install make for Alpine
-        run: |
-          apk add --no-cache make
-        shell: alpine.sh --root {0}
+      # - name: Install make for Alpine
+      #   run: |
+      #     apk add --no-cache make
+      #   shell: alpine.sh --root {0}
 
       - name: Build C bindings
         run: |

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -33,6 +33,11 @@ jobs:
             py3-pip
             make
 
+      - id: go-cache-paths
+        run: |
+          echo "::set-output name=go-build::$(go env GOCACHE)"
+          echo "::set-output name=go-mod::$(go env GOMODCACHE)"
+
       - uses: actions/checkout@v4
         with:
           submodules: recursive
@@ -41,6 +46,20 @@ jobs:
           # due to how pyscaffold set things up, but there is apparently a bug with fetch-tags.
           # https://github.com/actions/checkout/issues/1471
           fetch-depth: 0
+
+        # Cache go build cache, used to speedup go test
+      - name: Go Build Cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.go-cache-paths.outputs.go-build }}
+          key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
+
+      # Cache go mod cache, used to speedup builds
+      - name: Go Mod Cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.go-cache-paths.outputs.go-mod }}
+          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
 
       # - uses: actions/setup-python@v5
       #   with:

--- a/setup.py
+++ b/setup.py
@@ -20,15 +20,6 @@ from setuptools.dist import Distribution
 #         return True
 
 
-try:
-    from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
-    class bdist_wheel(_bdist_wheel):
-        def finalize_options(self):
-            _bdist_wheel.finalize_options(self)
-            self.root_is_pure = False
-except ImportError:
-    bdist_wheel = None
-
 if __name__ == "__main__":
     try:
         setup(
@@ -37,7 +28,6 @@ if __name__ == "__main__":
             package_data={
                 '':['libuplink.so', 'py.typed']
             },
-            cmdclass={'bdist_wheel': bdist_wheel},
             # distclass=BinaryDistribution
         )
     except:  # noqa

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,15 @@ from setuptools.dist import Distribution
 #         return True
 
 
+try:
+    from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
+    class bdist_wheel(_bdist_wheel):
+        def finalize_options(self):
+            _bdist_wheel.finalize_options(self)
+            self.root_is_pure = False
+except ImportError:
+    bdist_wheel = None
+
 if __name__ == "__main__":
     try:
         setup(
@@ -28,6 +37,7 @@ if __name__ == "__main__":
             package_data={
                 '':['libuplink.so', 'py.typed']
             },
+            cmdclass={'bdist_wheel': bdist_wheel},
             # distclass=BinaryDistribution
         )
     except:  # noqa


### PR DESCRIPTION
I'm having trouble getting cibuildwheel to work (#5). This should produce a build that's different in two ways:

1. Compiles using `musl`
    - Home Assistant containers use `musl` instead of `glibc` apparently, and I'm trying to get this to work in Home Assistant
    - Alpine linux uses `musl`, so that's why I'm using it
1. Compile for an ARM architecture
    - That is the architecture of the device I want this to run on

Eventually I'd like this package to be cross-platform, but I don't know how to do that yet.